### PR TITLE
#19 - Remove superfluous headers

### DIFF
--- a/_includes/partners.html
+++ b/_includes/partners.html
@@ -4,7 +4,6 @@
         <div class="col-lg-10 col-lg-offset-1">
             <h3>{{ site.organizersTitle }}</h3>
             {% for organizer in site.data.organizers %}
-            <h5>{{ organizer.group }}</h5>
             <ul class="list-inline">
                 {% for element in organizer.elements %}
                 <li {% if element.width != null %}style="width: {{ element.width }};"{% endif %}>
@@ -17,7 +16,6 @@
             {% endfor %}
             <h3>{{ site.partnersTitle }}</h3>
             {% for partner in site.data.partners %}
-            <h5>{{ partner.group }}</h5>
             <ul class="list-inline">
                 {% for element in partner.elements %}
                 <li {% if element.width != null %}style="width: {{ element.width }};"{% endif %}>


### PR DESCRIPTION
Per #19, removes superfluous headers from the homepage. There is only one organizer and one partner for MenderCon 2020, so the subheaders were unnecessary and awkward.

Here's the final look:

![image](https://user-images.githubusercontent.com/7128495/81834840-236ee000-9507-11ea-902f-2b5a50816092.png)
