### PR TITLE
Updates website for 2022

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,7 @@ exclude: ['/automation/', 'README.md', 'LICENSE.txt', 'CNAME']
 encoding: UTF-8
 
 # Site Settings
-title: "MenderCon 2021"
+title: "MenderCon 2022"
 email: "info@mendercon.com"
 description: "MenderCon is a conference for people who are passionate about modernizing and improving software systems"
 baseurl: ""
@@ -53,15 +53,16 @@ navigationLinks:
  - {permalink: "/speakers/", text: "Speakers"}
  - {permalink: "/coc/", text: "Code of Conduct"}
  - {permalink: "/testimonials/", text: "Testimonials"}
+ - {permalink: "http://legacycode.rocks", text: "Community"}
  - {permalink: "/faq/", text: "FAQ"}
 
 # Hero Block
 heroImage: "hero.jpg"
-heroTitle: "MenderCon 2021"
-eventDate: "May 13, 2021"
+heroTitle: "MenderCon 2022"
+eventDate: "June 8, 2022"
 heroButtons:
  - {permalink: "#about", text: "Learn more"}
- - {link: "https://hopin.to/events/mendercon-2021", text: "Get tickets"}
+ - {link: "https://hopin.to/events/mendercon-2022", text: "Get tickets"}
 
 # About Block
 aboutTitle: "About MenderCon"
@@ -115,7 +116,7 @@ venueFeatures: ["3 huge cinema screens", "Doulby Digital Surround EX audio syste
 # Tweets Feed Block
 tweetsFeedImage: "twitter-feed.jpg"
 tweetsFeedTitle: "What's Up?"
-twitterHashTag: "MenderCon2021"
+twitterHashTag: "MenderCon2022"
 
 # Partners Block
 organizersTitle: "Organizers"

--- a/_data/partners.yml
+++ b/_data/partners.yml
@@ -2,5 +2,4 @@
   group: "General sponsor"
   elements:
     - {name: "Corgibytes", description: "Corgibytes - old code; new tricks", link: "https://corgibytes.com", imageUrl: "corgibytes-logo.png"}
-    - {name: "Simple Thread", description: "UX Design - Software Engineering - DevOps", link: "https://www.simplethread.com", imageUrl: "ST Logo on Black.png"}
-    - {name: "Deep Roots", description: "Technical Skills at Scale", link: "https://www.digdeeproots.com", imageUrl: "deep-roots-id.png"}
+    

--- a/_data/schedule.yml
+++ b/_data/schedule.yml
@@ -1,6 +1,6 @@
 -
-  date: "2021-05-13"
-  dateReadable: "May 13"
+  date: "2022-06-8"
+  dateReadable: "June 8"
   tracks:
     - {title: "Track One", color: "#90be4e"}
     - {title: "Track Two", color: "#03a9f4"}

--- a/_data/sessions.yml
+++ b/_data/sessions.yml
@@ -54,16 +54,16 @@
   speakers: []
 -
   id: 011
-  title: "Starting an Open Source 'Repair Shop'"
-  description: "The heartwarming British reality show 'The Repair Shop' shows us experts restoring and reviving treasured heirlooms. In open source software, we have a similar opportunity -- when the right experts have a chance to work with legacy projects, we can refresh their digital, social, and -- if necessary -- financial and legal infrastructure, so they can thrive. Through my consulting business, I've helped get GNU Autoconf, PyPI, and other open source projects 'unstuck' over the last few years, and I'll share stories of those successes (one of them only took 15 hours of work). And I'll talk about the five major places open source projects get stuck (strategy, team, interfacing, workflow, and money) and how to address each. There's room for a lot of experts to join me in reviving these treasures and getting them shiny again; join me!"
-  speakers: [2]
+  title: "TBD"
+  description: "TBD"
+  speakers: []
 -
   id: 012
-  title: "7 Techniques to Tame a Legacy Codebase"
-  description: "We spend most of our time changing existing code. Often, there’s no test and the authors are long gone! It feels like a pain because you're always in a hurry, rushing to ship new features and bug fixes before the end of the Sprint. But what if you had a secret weapon? Let me share with you 7 concrete techniques that will help you regain control of any Legacy."
-  speakers: [3]
+  title: "TBD"
+  description: "TBD"
+  speakers: []
 -
   id: 013
-  title: "Proving It's Broken: Strategies for Modeling Systems"
-  description: "Troubled systems rarely have just one problem. This talk will explore using formal specification and system modeling to reason about a system's current state and constructing a plan to mender it. Using tools like TLA+, Alloy, and Z3 we can discover critical bugs in complex systems and demonstrate their impact without touching the system itself, then use that insight to make a case for substantial improvements."
-  speakers: [4]
+  title: "TBD"
+  description: "TBD"
+  speakers: []

--- a/_data/speakers.yml
+++ b/_data/speakers.yml
@@ -13,36 +13,13 @@
     - {name: "github", link: "https://github.com/mscottford"}
 -
   id: 2
-  name: "Sumana"
-  surname: "Harihareswara"
-  company: "Changeset Consulting"
+  name: "This could be"
+  surname: "You"
+  company: "Your Company"
   title: ""
   bio: ''
-  thumbnailUrl: Sumana_Harihareswara.jpg
+  thumbnailUrl: MenderCon_2021_Speaker_Placeholder.png
   rockstar: true
   social:
-    - {name: "linkedin", link: "http://www.linkedin.com/in/sumanah"}
-    - {name: "twitter", link: "https://twitter.com/brainwane"}
--
-  id: 3
-  name: "Nicolas"
-  surname: "Carlo"
-  company: "busbud"
-  title: ""
-  bio: ''
-  thumbnailUrl: Nicolas_Carlo.jpeg
-  rockstar: true
-  social:
-    - {name: "linkedin", link: "https://www.linkedin.com/in/%F0%9F%92%A1-nicolas-carlo-095b243b/"}
-    - {name: "twitter", link: "https://twitter.com/nicoespeon"}
--
-  id: 4
-  name: "Marianne"
-  surname: "Bellotti"
-  company: "Rebellion Defense"
-  title: ""
-  bio: ''
-  thumbnailUrl: Marianne_Bellotti.jpg
-  rockstar: true
-  social:
-    - {name: "twitter", link: "https://twitter.com/bellmar"}
+    - {name: "linkedin", link: "https://www.linkedin.com/company/corgibytes-llc"}
+    - {name: "twitter", link: "https://twitter.com/corgibytes"}

--- a/_faqs/001-what-platform-is-hosting-event.md
+++ b/_faqs/001-what-platform-is-hosting-event.md
@@ -2,7 +2,7 @@
 question: "What platform is being used to host the event? Why?"
 ---
 
-The event will be hosted on [Hopin](https://hopin.to/events/mendercon-2021). We feel that it is built for exactly the
+The event will be hosted on [Hopin](https://hopin.to/events/mendercon-2022). We feel that it is built for exactly the
 kind of event we want to have. It allows participants to easily create session, attend session, and move from one
 session to another if they didn’t like the one they find themselves in. It also has support for virtual vendor booths
 and randomized one-on-one networking sessions. We used it for our first ever MenderCon and really enjoyed it!

--- a/_includes/code-of-conduct.html
+++ b/_includes/code-of-conduct.html
@@ -4,7 +4,7 @@
     <div class="content-wrapper text-left">
         <div class="col-md-8 col-md-offset-2">
             <div>
-                <p>All attendees, speakers, sponsors, and volunteers at MenderCon 2021 are required to comply with the
+                <p>All attendees, speakers, sponsors, and volunteers at MenderCon are required to comply with the
                     following code of conduct. Organizers will enforce this code throughout the event. We expect
                     cooperation from all participants to help ensure a safe environment for everyone.</p>
             </div>
@@ -88,7 +88,7 @@
             <div>
                 <h5>Attribution</h5>
                 <p>This Code of Conduct is adapted from the Contributor Covenant, version 2.0, available at
-                    https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+                    <a href="https://www.contributor-covenant.org/version/2/0/code_of_conduct.html">https://www.contributor-covenant.org/version/2/0/code_of_conduct.html</a>.
                 </p>
             </div>
         </div>

--- a/_includes/hero.html
+++ b/_includes/hero.html
@@ -4,7 +4,7 @@
     <div class="content-wrapper">
     <div class="jumbotron">
         <div class="title animated hiding" data-animation="fadeInDown" data-delay="500">
-            <h1>Mender<span class="title-highlight">Con</span> 2021</h1>
+            <h1>Mender<span class="title-highlight">Con</span> 2022</h1>
             <p class="title-date">{{ site.eventDate }}</p>
             {% for button in site.heroButtons %}
             <a href="{% if button.permalink != null %} {{ button.permalink | prepend: site.baseurl }} {% else %} {{ button.link }} {% endif %}" class="btn btn-primary waves-effect waves-button waves-light waves-float" {% if button.link != null %}target="_blank"{% endif %}>{{ button.text }}</a>

--- a/_includes/schedule.html
+++ b/_includes/schedule.html
@@ -4,7 +4,7 @@
         {% for day in site.data.schedule %}
         <div class="schedule-table col-lg-8 col-md-10 col-md-offset-1">
             <div class="schedule-table-heading">
-                <p>Event times are listed in Eastern Daylight Time.</p>
+                <p>Event times are listed in Eastern Daylight Time. Check out previous years' sessions on our <a href="https://www.youtube.com/channel/UClRqBBLLGmS_lavhuo5r6Rw">YouTube channel</a>.</p>
             </div>
             <div class="timeslot track-header stick-header">
                 <div class="track-header-label"></div>

--- a/_includes/speakers-list.html
+++ b/_includes/speakers-list.html
@@ -52,10 +52,9 @@
             </div>
             <div class="row text-left appear-animation-trigger">
                 <div class="col-xs-12">
-                    <p>MenderCon is back in 2021 for our second annual conference!
+                    <p>MenderCon is back in 2022 for our third annual conference!
                         This year we will be offering two tracks: An open session
-                        track for anyone to present (similar to the full conference
-                        format last year), and (new this year) a standard event
+                        track for anyone to present and a standard event
                         track with pre-selected speakers. This is a call for papers
                         for the 2nd track.</p>
 
@@ -71,8 +70,8 @@
                         code, cloud/Kubernetes, dependency freshness, bug hunting,
                         etc. Whether it's totally trending or you're one of the only
                         people to have heard of it, we want to hear you talk about
-                        it! Entries are due by April 1st, with speaker notifications
-                        being sent out by April 9th.</p>
+                        it! Entries are due by May 15th, with speaker notifications
+                        being sent out by May 16th. <a href="https://forms.gle/Z4p7yZBkVf5HY3u29">Apply to Speak</a></p>
                     <p>And if your talk isn't selected for the standard track,
                         please host a session in the open track. This is a great way
                         to get some practice and feedback from others.</p>
@@ -97,8 +96,6 @@
 
                     <p>If you are interested in a sponsorship opportunity please
                         email us at sales at corgibytes dot com.</p>
-
-                    <p>Speaker applications are now closed.</p>
                 </div>
             </div>
         </div>

--- a/_includes/testimonials.html
+++ b/_includes/testimonials.html
@@ -4,7 +4,7 @@
             <div>
                 We had our first MenderCon in 2020 and the experience was something we will never forget!
                     It quickly solidified in our hearts that we had to make this a recurring event. Don't believe
-                    us? Here is what last year's attendees had to say!
+                    us? Here is what previous attendees had to say!
             </div>
             <div>
                 <h5>The Stats</h5>
@@ -28,8 +28,7 @@
                     <li>Your open meetings have given me a community I did not know I was
                         missing because I mainly see myself as an innovator, but with a big love and respect for decades old
                         software still being really valuable.</li>
-                    <li>I found interesting discussions. Price was unbeatable and it made me participate because I payed
-                       myself. I really liked the virtual format which made it possible for me to attend.</li>
+                    <li>I found interesting discussions. I really liked the virtual format which made it possible for me to attend.</li>
                     <li>It was my first open space conference and, as most people (I assume), I was skeptical about the format
                        but was surprised how well it worked.</li>
                     <li>Subject interesting and people awesome! Loved the followup mail we received

--- a/_includes/venue.html
+++ b/_includes/venue.html
@@ -6,7 +6,7 @@
             <div class="row venue-row">
               <div class="venue-col">
                 <p>
-                  MenderCon 2021 is a virtual event that's being hosted on the
+                  MenderCon 2022 is a virtual event that's being hosted on the
                   <a href="https://hopin.to">Hopin</a> platform. You get to attend
                   from the location of your choice, while still getting some of
                   the benefits of attending a conference in person. You'll get


### PR DESCRIPTION
1. Updated dates across website
2. Removed last year's speakers and put in placeholder image
3. Updated Call for Speakers link
4. Added "Community" link to toolbar
5. Removed last year's sponsors
6. Added link to YouTube channel on schedule page
7. Fixed link on Code of Conduct page
8. Updated testimonials page to remove reference to paying for the event